### PR TITLE
Correctly implemented the seek/tune interrupt handling.

### DIFF
--- a/Libraries/Arduino/src/SparkFunSi4703.h
+++ b/Libraries/Arduino/src/SparkFunSi4703.h
@@ -49,6 +49,15 @@ cables. Too short of a cable may degrade reception.
 class Si4703_Breakout
 {
   public:
+    /**
+     * Construct an object to communicate with the Si4703 tuner chip.
+     *
+     * @param resetPin  The device GPIO pin connected to the Si4703 RST pin.
+     * @param sdioPin   The device GPIO pin connected to the Si4703 SDA pin.
+     * @param sclkPin   The device GPIO pin connected to the Si4703 SCL pin.
+     * @param stcIntPin The device GPIO pin connected to the Si4703 GPIO2 pin.
+     *                  Set this to -1 to disable this pin.
+     */
     Si4703_Breakout(int resetPin, int sdioPin, int sclkPin, int sctIntPin);
     void powerOn();					// call in setup
 	void setChannel(int channel);  	// 3 digit channel number
@@ -60,6 +69,10 @@ class Si4703_Breakout
 									// result will be null terminated
 									// timeout in milliseconds
   private:
+
+  // Wait for the scanning/tuning operation to complete.
+  void waitForSTC(int maxWaitTimeMs);
+
     int  _resetPin;
 	int  _sdioPin;
 	int  _sclkPin;


### PR DESCRIPTION
The prior implementation was never correctly checking the interrupt
pin (`_stcIntPin`) when seeking or tuning to a new channel. It was
only checking that the pin variable, which contains the GPIO pin
number, was non-zero - never the actual state of the pin. This
resulted in the the code immediately concluding that the seek/tune
operation was complete, that is unless `_stcIntPin` was set to zero,
whereby the device would spin until reset by the Arduino watchdog
timer.

This implementation installs an interrupt handler to properly
detect that the Si4703's GPIO2 pin has been set low. This change
also allows `_stcIntPin` to be set to a value of `-1` to disable
interrupt handling. The implementation will then poll the tuner
to detect that seek/tune has completed. This might be desireable
when the user does not want to connect the Si4703 GPIO2 pin to
the controller (for whatever reason).